### PR TITLE
Adding timeout so full DFU works seamlessly

### DIFF
--- a/dist/dfu.js
+++ b/dist/dfu.js
@@ -135,8 +135,9 @@
             .then(function() {
                 log("modeData written");
                 setTimeout(function() {
-                    resolve(device);
-                }, 2e3);
+                    resolve(device); // TODO: Remove this when gattserverdisconnected is implemented.
+                }, 1e3);
+                
             })
             .catch(function(error) {
                 error = "writeMode error: " + error;
@@ -219,7 +220,7 @@
             .then(function(gattServer) {
                 return new Promise(function(resolve) {
                     server = gattServer;
-                    setTimeout(resolve, 2e3);
+                    setTimeout(resolve, 2e3); // This delay is needed because BlueZ needs time to update it's cache.
                 });
             })
             .then(function() {

--- a/dist/dfu.js
+++ b/dist/dfu.js
@@ -136,7 +136,7 @@
                 log("modeData written");
                 setTimeout(function() {
                     resolve(device);
-                }, 5e3);
+                }, 2e3);
             })
             .catch(function(error) {
                 error = "writeMode error: " + error;
@@ -219,9 +219,7 @@
             .then(function(gattServer) {
                 return new Promise(function(resolve) {
                     server = gattServer;
-                    setTimeout(function() {
-                          resolve();
-                  }, 5e3);
+                    setTimeout(resolve, 2e3);
                 });
             })
             .then(function() {

--- a/dist/dfu.js
+++ b/dist/dfu.js
@@ -217,8 +217,15 @@
 
             device.gatt.connect()
             .then(function(gattServer) {
+                return new Promise(function(resolve) {
+                    server = gattServer;
+                    setTimeout(function() {
+                          resolve();
+                  }, 5e3);
+                });
+            })
+            .then(function() {
                 log("connected to device");
-                server = gattServer;
                 return server.getPrimaryService(SERVICE_UUID);
             })
             .then(function(primaryService) {

--- a/dist/hex2bin.js
+++ b/dist/hex2bin.js
@@ -40,7 +40,7 @@
 }(this, function() {
     'use strict';
     
-    var RECORD_TYPE = { // I32HEX files use only record types 00, 01, 04, 05.
+    var RecordType = { // I32HEX files use only record types 00, 01, 04, 05.
         DATA : '00',
         END_OF_FILE : '01',
         EXTENDED_SEGMENT_ADDRESS : '02',
@@ -58,13 +58,13 @@
         
         do {
             record = hexLines.shift();
-        } while (record.substr(7, 2) != RECORD_TYPE.EXTENDED_LINEAR_ADDRESS);
+        } while (record.substr(7, 2) != RecordType.EXTENDED_LINEAR_ADDRESS);
         
         var firstBaseAddress = parseInt(record.substr(9, 4), 16) << 16;
         
         do {
             record = hexLines.shift();
-        } while (record.substr(7, 2) != RECORD_TYPE.DATA);
+        } while (record.substr(7, 2) != RecordType.DATA);
         var firstDataRecordAddressOffset = parseInt(record.substr(3, 4), 16);
 
         var startAddress = firstBaseAddress + firstDataRecordAddressOffset;
@@ -81,14 +81,14 @@
         
         do {
             record = hexLines.pop();
-        } while (record.substr(7, 2) != RECORD_TYPE.DATA);
+        } while (record.substr(7, 2) != RecordType.DATA);
         
         var lastDataRecordLength = parseInt(record.substr(1, 2), 16);
         var lastDataRecordAddressOffset = parseInt(record.substr(3, 4), 16);
         
         do {
             record = hexLines.pop();
-        } while (record.substr(7, 2) != RECORD_TYPE.EXTENDED_LINEAR_ADDRESS);
+        } while (record.substr(7, 2) != RecordType.EXTENDED_LINEAR_ADDRESS);
         
         var lastBaseAddress = parseInt(record.substr(9, 4), 16) << 16;
         
@@ -135,7 +135,7 @@
             
             switch (line.substr(7, 2)) {
               
-                case RECORD_TYPE.DATA:
+                case RecordType.DATA:
                     var length = parseInt(line.substr(1, 2), 16);
                     var addressOffset = parseInt(line.substr(3, 4), 16);
                     var data = line.substr(9, length * 2);
@@ -146,17 +146,17 @@
                         }
                     }
                     break;
-                case RECORD_TYPE.END_OF_FILE:
+                case RecordType.END_OF_FILE:
                     log('done converting hex file to binary');
                     break;
-                case RECORD_TYPE.EXTENDED_SEGMENT_ADDRESS:
+                case RecordType.EXTENDED_SEGMENT_ADDRESS:
                     throw 'ERROR - invalid hex file - extended segment address is not handled';
-                case RECORD_TYPE.START_SEGMENT_ADDRESS:
+                case RecordType.START_SEGMENT_ADDRESS:
                     throw 'ERROR - invalid hex file - start segment address is not handled';
-                case RECORD_TYPE.EXTENDED_LINEAR_ADDRESS:
+                case RecordType.EXTENDED_LINEAR_ADDRESS:
                     baseAddress = parseInt(line.substr(9, 4), 16) << 16;
                     break;
-                case RECORD_TYPE.START_LINEAR_ADDRESS:
+                case RecordType.START_LINEAR_ADDRESS:
                     log('ignore records of type start linear address');
                     break;
                 default:


### PR DESCRIPTION
Currently there is a timeout in writeMode after the device disconnects and in connect() after we call device.gatt.connect() and before discovering services. With these timeouts DFU works seamlessly.

Also made constant variables naming styles more consistent.
