### PR TITLE
Add timeouts so entire DFU process works

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ node example_node <device-type>
 
 Where ```<device-type>``` is one of ```nrf51``` or ```nrf52```.
 
-## Updating the SoftDevice or Bootloader (nRF52 only)
+## Updating the SoftDevice or Bootloader
 
 The ```.hex``` files below can be transferred via DFU to test SoftDevice and Bootloader updates respectivley:
 

--- a/dist/dfu.js
+++ b/dist/dfu.js
@@ -134,6 +134,9 @@
             })
             .then(function() {
                 log("modeData written");
+                setTimeout(function() {  // TODO: Remove this when gattserverdisconnected event is implemented and possibly put a timeout in that event handler before resolving.
+                    resolve(device);
+                }, 2000);
             })
             .catch(function(error) {
                 error = "writeMode error: " + error;
@@ -215,7 +218,12 @@
             device.gatt.connect()
             .then(function(gattServer) {
                 log("connected to device");
-                server = gattServer;
+                return new Promise(function(resolve) {
+                    server = gattServer;
+                    setTimeout(resolve, 2000); // This delay is needed because BlueZ needs time to update it's cache.
+                });
+            })
+            .then(function() {
                 return server.getPrimaryService(serviceUUID);
             })
             .then(function(primaryService) {


### PR DESCRIPTION
Added timeouts. Both are needed (we may be able to remove writeMode() after disconnect event fires). 2 seconds seems like the minimum consistent time I've found but nothing scientific here.
