### PR TITLE
Enforce delay after control messages are sent

### DIFF
--- a/src/secure-dfu.ts
+++ b/src/secure-dfu.ts
@@ -299,7 +299,12 @@ export class SecureDfu extends EventDispatcher {
     }
 
     private sendControl(operation: Array<number>, buffer?: ArrayBuffer): Promise<DataView> {
-        return this.sendOperation(this.controlChar, operation, buffer);
+        return new Promise(resolve => {
+            this.sendOperation(this.controlChar, operation, buffer)
+            .then(resp => {
+                setTimeout(() => resolve(resp), this.delay);
+            });
+        });
     }
 
     private transferInit(buffer: ArrayBuffer): Promise<DataView> {


### PR DESCRIPTION
Extends on @fhaubold 's PR #29 to enforce the same optional delay after control packets are sent. Without this change, I had issues on Chrome on Windows 10. With this change, and a delay of 5ms all issues are resolved.