### PR TITLE
sendControl causing "uncaught in promise" error

### DIFF
--- a/src/secure-dfu.ts
+++ b/src/secure-dfu.ts
@@ -306,10 +306,12 @@ export class SecureDfu extends EventDispatcher {
     }
 
     private sendControl(operation: Array<number>, buffer?: ArrayBuffer): Promise<DataView> {
-        return new Promise(resolve => {
+        return new Promise((resolve, reject) => {
             this.sendOperation(this.controlChar, operation, buffer)
             .then(resp => {
                 setTimeout(() => resolve(resp), this.delay);
+            }).catch(err => {
+                reject(err);
             });
         });
     }


### PR DESCRIPTION
Ran into a case where errors in sendControl could not be handled.

Made change to explicitly handle and reject an errors happening in sendControl.