### PR TITLE
If DFU update fails, automatically try again but with a delay between writes

### DIFF
--- a/src/secure-dfu.ts
+++ b/src/secure-dfu.ts
@@ -548,7 +548,14 @@ export class SecureDfu extends EventDispatcher {
                     resolve(device);
                 });
             })
-            .catch(error => reject(error));
+            .catch(error => {
+                if (this.delay === 0) {
+                    this.log("DFU update failed, but delay=0. Trying again with delay=10...");
+                    this.delay = 10;
+                    return this.update(device, init, firmware);
+                }
+                reject(error);
+            });
         });
     }
 }


### PR DESCRIPTION
If DFU update fails but we're not using any delay between writes, try again but with a delay.

This fixes an issue with *some* Windows 11 PCs where a DFU update would fail on the first 4096 byte block

Fix #80